### PR TITLE
Updates the download link and resolve issue with out of date SSL certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 WORKDIR /tmp
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget fontconfig libfontconfig1 libfreetype6 libjpeg-turbo8 libx11-6 libxext6 libxrender1 xfonts-base xfonts-75dpi && \
-    wget -q http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb && \
-    dpkg -i wkhtmltox-0.12.2.1_linux-trusty-amd64.deb && \
+    apt-get install -y wget fontconfig libfontconfig1 libfreetype6 libjpeg-turbo8 libx11-6 libxext6 libxrender1 xfonts-base xfonts-75dpi && \
+    wget -q https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb && \
+    dpkg -i wkhtmltox_0.12.5-1.trusty_amd64.deb && \
     rm /usr/local/bin/wkhtmltoimage && \
     apt-get purge -y wget && \
     apt-get autoremove -y && \


### PR DESCRIPTION
Hello,

This pull request addresses two issues noted whilst using this Docker image:
• The address for the download of wkhtmltopdf has moved to its official location on Github now.
• The HTTPS url will fail because the SSL certificates need to be updated in the image
Hopefully I've addressed both of those with this change.

Any questions about this let me know!